### PR TITLE
Fix memory leak.

### DIFF
--- a/tinycurl.cpp
+++ b/tinycurl.cpp
@@ -18,7 +18,7 @@ TinyCurl::TinyCurl(const std::string &url)
     m_url = url;
 }
 
-TinyCurl::~TinyCurl()
+TinyCurl::~TinyCurl() noexcept
 {
     curl_easy_cleanup(m_handle);
     curl_slist_free_all(opt_list);

--- a/tinycurl.h
+++ b/tinycurl.h
@@ -35,7 +35,7 @@ public:
     };
 
     TinyCurl(const std::string &url);
-    ~TinyCurl();
+    ~TinyCurl() noexcept;
 
     typedef std::map<std::string,std::string> headers_t;
 
@@ -58,7 +58,7 @@ private:
     TinyCurl(const TinyCurl &);
 
     void setOptions();
-    void setHTTPHeaders(const headers_t &hdrs) const;
+    void setHTTPHeaders(const headers_t &hdrs);
 
     void curlPerform();
 
@@ -66,4 +66,5 @@ private:
     std::string m_url;
     std::string m_data;
     std::string m_upload_data;
+    struct curl_slist *opt_list = NULL;
 };


### PR DESCRIPTION
As you know, plain C has not RAII, so the structure created in 
https://github.com/asashnov/tinycurl/blob/00b89ffaf753e024fbdb2dc0cacc679b99fb9901/tinycurl.cpp#L29

Is never deallocated by the underlying library. I opted in this pull request to let this structure as a private member and clean in the destructor:
https://github.com/phoemur/tinycurl/blob/b95a68f84ecc171638d00b5de688869f9d7493f3/tinycurl.cpp#L24

Also improved the resource creation in the constructor and better cleanup in this pull request. 
This small change seems to make a huge difference, as you can see:

Valgrind before changes:
`
    ==3320== 

    ==3320== HEAP SUMMARY:

    ==3320==     in use at exit: 96,824 bytes in 3,233 blocks

    ==3320==   total heap usage: 4,324 allocs, 1,091 frees, 391,637 bytes allocate

    ==3320==

    ==3320== LEAK SUMMARY:

    ==3320==    definitely lost: 0 bytes in 0 blocks

    ==3320==    indirectly lost: 0 bytes in 0 blocks

    ==3320==      possibly lost: 0 bytes in 0 blocks

    ==3320==    still reachable: 96,824 bytes in 3,233 blocks

    ==3320==         suppressed: 0 bytes in 0 blocks

    ==3320== Reachable blocks (those to which a pointer was found) are not shown.

    ==3320== To see them, rerun with: --leak-check=full --show-leak-kinds=all

    ==3320== 

    ==3320== For counts of detected and suppressed errors, rerun with: -v

    ==3320== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
 `

Valgrind After changes:
`
    ==3419== 

    ==3419== HEAP SUMMARY:

    ==3419==     in use at exit: 528 bytes in 10 blocks

    ==3419==   total heap usage: 4,324 allocs, 4,314 frees, 391,637 bytes allocated

    ==3419== 

    ==3419== LEAK SUMMARY:

    ==3419==    definitely lost: 0 bytes in 0 blocks

    ==3419==    indirectly lost: 0 bytes in 0 blocks

    ==3419==      possibly lost: 0 bytes in 0 blocks

    ==3419==    still reachable: 528 bytes in 10 blocks

    ==3419==         suppressed: 0 bytes in 0 blocks

    ==3419== Reachable blocks (those to which a pointer was found) are not shown.

    ==3419== To see them, rerun with: --leak-check=full --show-leak-kinds=all

    ==3419== 

    ==3419== For counts of detected and suppressed errors, rerun with: -v

    ==3419== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)`

I could not eliminate all leaks, though going from 96,824 to 528 bytes in use at exit semmed worth a pull request.

Thanks for your attention